### PR TITLE
Feature: Power limitation

### DIFF
--- a/Maiskolben_TFT/Maiskolben_TFT.ino
+++ b/Maiskolben_TFT/Maiskolben_TFT.ino
@@ -872,10 +872,19 @@ void compute(void) {
 	last_measured = cur_t;
 
 	heaterPID.Compute();
-	if (error != NO_ERROR || off)
+
+	// Power limitation.
+	// Tips are rated for 40W, do not exceed that.
+	// note t-hat we have inherently only 50% PWM, as we have it on 10ms and then wait with pwm off for another 10ms.
+	// Formula: P = 0.5 * ( U^2 / ( R )) * (pwm)
+	float pwm_max = 2 * PMAX / ((v*v) / 2.4);
+	if (pwm_max > pid_val) pwm_max = pid_val;
+
+	if (error != NO_ERROR || off) {
 		pwm = 0;
-	else
-		pwm = min(255,pid_val*255);
+	} else {
+		pwm = min(255, pwm_max * 255);
+	}
 	analogWrite(HEATER_PWM, pwm);
 }
 

--- a/Maiskolben_TFT/definitions.h
+++ b/Maiskolben_TFT/definitions.h
@@ -13,6 +13,8 @@
 #define TEMP_STBY   150
 #define TEMP_COLD   (adc_offset + 15)
 
+#define PMAX (40) // max watts to pump into the tip. (note: Weller specifies the tips as 40W; the big RT-11 has 55W)
+
 #define SHUTOFF_ACTIVE
 #define BOOTHEAT_ACTIVE
 


### PR DESCRIPTION
Weller tips are rated for 40W (at least most of them). On higher input
voltage, this is exceeded.

This feature limits it by putting a cap on the pwm, dependent on the input
voltage.